### PR TITLE
makeコマンドの為の修正

### DIFF
--- a/Forest_Program/build.xml
+++ b/Forest_Program/build.xml
@@ -98,6 +98,7 @@
 
 	<target name="test" depends="all" description="test">
 		<exec executable="java" spawn="false">
+			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/test.txt" />
 			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/tree.txt" />
 			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/forest.txt" />
 			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/semilattice.txt" />
@@ -149,21 +150,20 @@
 
 	<target name="tree" depends="all" description="tree">
 		<exec executable="java" spawn="false">
-			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${package}.jar ${srcdir}/../resource/data/tree.txt" />
-		</exec>
-		<exec executable="date" spawn="false" />
+			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/tree.txt" />
+		</exec> <exec executable="date" spawn="false" />
 	</target>
 
 	<target name="forest" depends="all" description="forest">
 		<exec executable="java" spawn="false">
-			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${package}.jar ${srcdir}/../resource/data/forest.txt" />
+			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/forest.txt" />		
 		</exec>
 		<exec executable="date" spawn="false" />
 	</target>
 
 	<target name="semilattice" depends="all" description="semilattice">
 		<exec executable="java" spawn="false">
-			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${package}.jar ${srcdir}/../resource/data/semilattice.txt" />
+			<arg line="-Dfile.encoding=UTF-8 -Xmx512m -Xss1024k -jar ${destdir}/${ant.project.name}.jar ${srcdir}/../resources/data/semilattice.txt" />		
 		</exec>
 		<exec executable="date" spawn="false" />
 	</target>
@@ -173,9 +173,6 @@
 			file="${basedir}/${destdir}/${ant.project.name}.jar" 
 			todir="${instdir}"
 		/>
-		<exec executable="chmod">
-			<arg line="755 ${instdir}/../../MacOS/Automator\ Application\ Stub" />
-		</exec>
 		<exec executable="date" spawn="false" />
 	</target>
 

--- a/Forest_Program/src/main/resources/data/test.txt
+++ b/Forest_Program/src/main/resources/data/test.txt
@@ -1,0 +1,60 @@
+trees:
+Object
+|-- Magnitude
+|-- |-- ArithmeticValue
+|-- |-- |-- Number
+|-- |-- |-- |-- Integer
+|-- |-- |-- |-- |-- SmallInteger
+|-- |-- Character
+Object
+|-- Collection
+|-- |-- SequenceableCollection
+|-- |-- |-- ArrayedCollection
+|-- |-- |-- |-- Array
+|-- |-- |-- |-- String
+|-- |-- Set
+|-- |-- |-- Dictionary
+Object
+|-- Stream
+|-- |-- PositionableStream
+|-- |-- |-- InternalStream
+|-- |-- |-- |-- ReadStream
+nodes:
+1, Magnitude
+2, ArithmeticValue
+3, Number
+4, Integer
+5, SmallInteger
+6, Character
+7, Collection
+8, SequenceableCollection
+9, ArrayedCollection
+10, Array
+11, String
+12, Set
+13, Dictionary
+14, Stream
+15, PositionableStream
+16, InternalStream
+17, ReadStream
+18, Object
+19, Object
+20, Object
+branches:
+18, 1
+1, 2
+1, 6
+2, 3
+3, 4
+4, 5
+19, 7
+7, 8
+7, 12
+8, 9
+9, 10
+9, 11
+12, 13
+20, 14
+14, 15
+15, 16
+16, 17


### PR DESCRIPTION
install以外のmakeコマンドが目的通りに動作するようにしました。
make testでtest.txtを実行するために、test.txtを追加しました。